### PR TITLE
Support UTF-8 and `?`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -120,6 +120,8 @@ let
 
               isStar = patChar == "*";
 
+              isQmark = patChar == "?";
+
               isEscape = patChar == "\\";
 
             in
@@ -128,7 +130,7 @@ let
               else if isEscape && ((patIdx + 1) >= patLen) then
                 # todo: ErrBadPattern
                 false
-              else if patChar == nameChar then
+              else if patChar == nameChar || (isQmark && !(isSeparator nameChar)) then
                 doMatch (args // {
                   nameIdx = nameIdx + 1;
                   # If escaped, skip an additional rune.

--- a/default.nix
+++ b/default.nix
@@ -130,11 +130,16 @@ let
               else if isEscape && ((patIdx + 1) >= patLen) then
                 # todo: ErrBadPattern
                 false
+              else if isEscape && elemAt patternChars (patIdx + 1) == nameChar then
+                doMatch (args // {
+                  nameIdx = nameIdx + 1;
+                  patIdx = patIdx + 2;
+                  startOfSegment = isSeparator patChar;
+                })
               else if patChar == nameChar || (isQmark && !(isSeparator nameChar)) then
                 doMatch (args // {
                   nameIdx = nameIdx + 1;
-                  # If escaped, skip an additional rune.
-                  patIdx = patIdx + 1 + (if isEscape then 1 else 0);
+                  patIdx = patIdx + 1;
                   startOfSegment = isSeparator patChar;
                 })
               else

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,17 @@
 { lib }:
 let
   inherit (builtins)
-    stringLength
-    substring
+    elemAt
+    length
   ;
 
   inherit (lib)
+    concatStrings
     foldl'
     hasPrefix
     removePrefix
+    sublist
+    utf8
   ;
 
   fs = lib.fileset;
@@ -68,7 +71,7 @@ let
       fs.unions
         (map
           (name: root + "/${name}")
-          (internal.globSegments root pattern true)
+          (internal.globSegments root (utf8.chars pattern) true)
         );
 
     # Determines whether a given file name matches a glob pattern.
@@ -92,11 +95,12 @@ let
     #   match "a\\*b" "a*b"   # Returns true
     match = pattern: name:
       let
-        patLen = stringLength pattern;
+        patternChars = utf8.chars pattern;
+        nameChars = utf8.chars name;
 
-        nameLen = stringLength name;
+        patLen = length patternChars;
 
-        charAt = str: i: substring i 1 str;
+        nameLen = length nameChars;
 
         isSeparator = char: char == "/";
 
@@ -105,14 +109,14 @@ let
         }@args:
           if nameIdx >= nameLen then
             internal.isZeroLengthPattern
-              (substring patIdx (patLen - patIdx) pattern)
+              (concatStrings (sublist patIdx (patLen - patIdx) patternChars))
           else if patIdx >= patLen then
             handleBacktrack args
           else
             let
-              nameChar = charAt name nameIdx;
+              nameChar = elemAt nameChars nameIdx;
 
-              patChar = charAt pattern patIdx;
+              patChar = elemAt patternChars patIdx;
 
               isStar = patChar == "*";
 
@@ -139,7 +143,7 @@ let
             # Check ahead for a second '*'.
             nextPatIdx = args.patIdx + 1;
 
-            isDoublestar = nextPatIdx < patLen && charAt pattern nextPatIdx == "*";
+            isDoublestar = nextPatIdx < patLen && elemAt patternChars nextPatIdx == "*";
 
             starBacktrack = {
               inherit (args) nameIdx;
@@ -149,7 +153,7 @@ let
             };
 
             # Doublestar must also end with separator, treating as single star.
-            doublestarAfterChar = charAt pattern (nextPatIdx + 1);
+            doublestarAfterChar = elemAt patternChars (nextPatIdx + 1);
 
             doublestarBacktrack = {
               inherit (args) nameIdx;
@@ -184,10 +188,10 @@ let
               nameIdx = args.starBacktrack.nameIdx + 1;
             };
 
-            starNameChar = charAt name args.starBacktrack.nameIdx;
+            starNameChar = elemAt nameChars args.starBacktrack.nameIdx;
 
             nextSeparatorIdx =
-              internal.findNextSeparator name args.doublestarBacktrack.nameIdx;
+              internal.findNextSeparator nameChars args.doublestarBacktrack.nameIdx;
 
             doublestarBacktrack = {
               inherit (args.doublestarBacktrack) patIdx;

--- a/flake.lock
+++ b/flake.lock
@@ -17,7 +17,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": "nixpkgs-lib",
+        "utf8": "utf8"
+      }
+    },
+    "utf8": {
+      "locked": {
+        "lastModified": 1708377658,
+        "narHash": "sha256-iRl5NcyN8coR464CLNGWx9I3YWYIsk45JY6dFJVbcF8=",
+        "owner": "figsoda",
+        "repo": "utf8",
+        "rev": "ce04eef066a4a682f2ef0eba8e56e4da9b8f14aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "figsoda",
+        "repo": "utf8",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,9 @@
   description = "Simplify Nix source management using familiar glob patterns";
 
   inputs.nixpkgs-lib.url = "github:nix-community/nixpkgs.lib";
+  inputs.utf8.url = "github:figsoda/utf8";
 
-  outputs = { self, nixpkgs-lib }:
+  outputs = { self, nixpkgs-lib, utf8 }:
     let 
       inherit (builtins)
         fromJSON
@@ -25,13 +26,13 @@
 
       pkgs = import nixpkgs { inherit system; };
 
-      globset = import self { inherit (nixpkgs-lib) lib; };
+      globset = import self { lib = nixpkgs-lib.lib // { utf8 = utf8.lib; }; };
    
     in {
       lib = globset;
 
       tests.${system} = import ./internal/tests.nix {
-        lib = nixpkgs-lib.lib // { inherit globset; };
+        lib = nixpkgs-lib.lib // { inherit globset; utf8 = utf8.lib; };
       };
 
       checks.${system}.default = pkgs.runCommand "tests" {
@@ -42,6 +43,7 @@
           --eval-store "$HOME" \
           --extra-experimental-features flakes \
           --override-input nixpkgs-lib ${nixpkgs-lib} \
+          --override-input utf8 ${utf8} \
           --flake ${self}#tests
         touch $out
       '';

--- a/internal/default.nix
+++ b/internal/default.nix
@@ -129,7 +129,7 @@ in rec {
           char = head chars;
           rest = tail chars;
         in
-          if char == "*" then i
+          if char == "*" || char == "?" then i
           else if char == "\\" then
             if rest == [] then -1
             else find (i + 2) (tail rest)
@@ -165,7 +165,7 @@ in rec {
 
   unescapeMeta = str:
     replaceStrings
-      [ "\\*" ]
-      [ "*" ]
+      [ "\\*" "\\?" ]
+      [ "*" "?" ]
       str;
 }

--- a/internal/tests.nix
+++ b/internal/tests.nix
@@ -37,11 +37,13 @@ in {
     tests = [
       { str = ""; expected = -1; }
       { str = "*abc"; expected = 0; }
+      { str = "a\\?b"; expected = -1; }
       { str = "\\*a*"; expected = 3; }
       { str = "abc\\*def"; expected = -1; }
       { str = "ab\\*cd*ef"; expected = 6; }
       { str = "no\\*meta"; expected = -1; }
       { str = "\\\\*meta"; expected = 2; }
+      { str = "\\\\?meta"; expected = 2; }
       { str = "escaped\\"; expected = -1; }
       { str = "escaped\\\\"; expected = -1; }
     ];
@@ -92,6 +94,19 @@ in {
       { pattern = "a/**/c"; path = "a/b/c"; expected = true; }
       { pattern = "a/**/d"; path = "a/b/c/d"; expected = true; }
       { pattern = "a/\\**"; path = "a/b/c"; expected = false; }
+
+      # Question mark
+      { pattern = "?"; path = "a"; expected = true; }
+      { pattern = "?"; path = "Æ"; expected = true; }
+      { pattern = "?"; path = "ab"; expected = false; }
+      { pattern = "?"; path = "/"; expected = false; }
+      { pattern = "/?"; path = "/"; expected = false; }
+      { pattern = "a?b?c?d?e"; path = "axbxcxdxe"; expected = true; }
+      { pattern = "a?b?c?d?e"; path = "a一b二c三d四e"; expected = true; }
+      { pattern = "a?b?c?d???e"; path = "a一b二c三d四e"; expected = false; }
+      { pattern = "a?b?c?d?e"; path = "axbxxcxdxe"; expected = false; }
+      { pattern = "a?b?c?d?e"; path = "axbxcxd/e"; expected = false; }
+      { pattern = "\\?"; path = "a"; expected = false; }
     ];
   };
 }

--- a/internal/tests.nix
+++ b/internal/tests.nix
@@ -75,6 +75,8 @@ in {
       { pattern = "a*b*c*d*e*/f"; path = "axbxcxdxe/xxx/f"; expected = false; }
       { pattern = "a*b*c*d*e*/f"; path = "axbxcxdxexxx/fff"; expected = false; }
       { pattern = "a\\*b"; path = "ab"; expected = false; }
+      { pattern = "a\\*b"; path = "a*b"; expected = true; }
+      { pattern = "\\*"; path = "*"; expected = true; }
 
       # Globstar / doublestar
       { pattern = "**"; path = ""; expected = true; }
@@ -107,6 +109,12 @@ in {
       { pattern = "a?b?c?d?e"; path = "axbxxcxdxe"; expected = false; }
       { pattern = "a?b?c?d?e"; path = "axbxcxd/e"; expected = false; }
       { pattern = "\\?"; path = "a"; expected = false; }
+      { pattern = "\\?"; path = "?"; expected = true; }
+      { pattern = "a\\?b"; path = "a?b"; expected = true; }
+
+      # Escapes
+      { pattern = "\\\\"; path = "\\"; expected = true; }
+      { pattern = "\\"; path = "\\"; expected = false; }
     ];
   };
 }

--- a/internal/tests.nix
+++ b/internal/tests.nix
@@ -33,7 +33,7 @@ let
 in {
   firstUnescapedMeta = mkSuite {
     testNameFn = testCase: ''firstUnescapedMeta "${testCase.str}"'';
-    valueFn = testCase: internal.firstUnescapedMeta testCase.str;
+    valueFn = testCase: internal.firstUnescapedMeta (lib.utf8.chars testCase.str);
     tests = [
       { str = ""; expected = -1; }
       { str = "*abc"; expected = 0; }


### PR DESCRIPTION
The two features are bundled together because I couldn't find a way to test UTF-8, since valid multibyte UTF-8 characters cannot contain ASCII characters like `*` and `/`. Invalid multibyte UTF-8 characters are allowed on ext4 Linux, but Nix seems to normalize them into valid UTF-8 and gets rid of the invalid `*` and `/` bytes in the process.

Added a fix for patterns like `\*`, since `*` is a valid character in file names, at least on ext4 Linux. I made sequences like `\t` match the character `t` instead of a tab, but didn't add any tests for it, since I'm not sure if this is a behavior we want to keep.

The UTF-8 feature is implemented using https://github.com/figsoda/utf8. The implementation might be a little inefficient because it converts back and forth between strings and lists of characters using `concatStrings` and `utf8.chars`, but hopefully shouldn't be a big deal because of how short glob pattern usually are. I went with this route because otherwise the diff might be a bit hard to review.

closes #5 
closes #6